### PR TITLE
Fixed extra white space issue on book preview modals

### DIFF
--- a/openlibrary/macros/BookPreview.html
+++ b/openlibrary/macros/BookPreview.html
@@ -10,13 +10,13 @@ $# :param str ocaid:
 
 $if render_once('book-preview-floater'):
   <div class="hidden">
-    <div class="floater" id="bookPreview">
+    <div id="bookPreview">
       <div class="book-preview">
         <div class="floaterHead">
           <h2>$_('Preview Book')</h2>
           <a class="dialog--close" data-key="book_preview">&times;<span class="shift">$_("Close")</span></a>
         </div>
-        <div class="iframe-container">
+        <div>
           <iframe style="width:100%; height:515px"></iframe>
           <p class="learn-more">
             <a data-key="book_preview_learn_more"


### PR DESCRIPTION
<!-- What issue does this PR close? -->

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Refactor/Fix excess whitespace on book preview pop-ups

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Go to this link (or any book with preview), and click preview: https://openlibrary.org/works/OL16086453W/Pioneers?edition=key%3A/books/OL24982896M 

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
Before:
<img width="1470" alt="Screenshot 2024-12-11 at 9 02 59 AM" src="https://github.com/user-attachments/assets/3d2cdb84-69ad-4968-ab03-47fa377a13d2">

After: 
<img width="1470" alt="Screenshot 2024-12-11 at 9 02 33 AM" src="https://github.com/user-attachments/assets/70746c00-652a-4c81-926b-78b48a9303d3">

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
